### PR TITLE
Allow uppercase letters in methods

### DIFF
--- a/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -109,14 +109,14 @@ class moodle_Sniffs_NamingConventions_ValidFunctionNameSniff
                 !in_array($methodname, $this->permittedmethods)) {
 
             if ($scopespecified === true) {
-                $error = ucfirst($scope) . ' method name "' . $classname . '::' .
-                        $methodname .'" must be in lower-case letters only';
+                $warning = ucfirst($scope) . ' method name "' . $classname . '::' .
+                        $methodname .'" should be in lower-case letters only';
             } else {
-                $error = 'method name "' . $classname . '::' . $methodname .
-                        '" must be in lower-case letters only';
+                $warning = 'method name "' . $classname . '::' . $methodname .
+                        '" should be in lower-case letters only';
             }
 
-            $phpcsfile->adderror($error, $stackptr);
+            $phpcsfile->addWarning($warning, $stackptr);
             return;
         }
     }


### PR DESCRIPTION
Sometimes I need to extend some existing class and override method that already has uppercase letter in its name.